### PR TITLE
add error field as culprit, even when no stack tracing

### DIFF
--- a/sentry.go
+++ b/sentry.go
@@ -204,6 +204,11 @@ func (hook *SentryHook) Fire(entry *logrus.Entry) error {
 			currentStacktrace := raven.NewStacktrace(stConfig.Skip, stConfig.Context, stConfig.InAppPrefixes)
 			packet.Interfaces = append(packet.Interfaces, currentStacktrace)
 		}
+	} else {
+		// set the culprit even when the stack trace is disabled, as long as we have an error
+		if err, ok := df.getError(); ok {
+			packet.Culprit = err.Error()
+		}
 	}
 
 	// set other fields


### PR DESCRIPTION
when stack traces are enabled, the error is added as the culprit but not when stack tracing is disabled.

I'd like to have the logrus standardised field `error` as the culprit all the time. This MR adds the error as culprit when stack tracing is disabled.
