### PR TITLE
Use alfatraining raven go

### DIFF
--- a/data_field.go
+++ b/data_field.go
@@ -3,7 +3,7 @@ package logrus_sentry
 import (
 	"net/http"
 
-	"github.com/getsentry/raven-go"
+	"github.com/alfatraining/raven-go"
 	"github.com/sirupsen/logrus"
 )
 

--- a/sentry.go
+++ b/sentry.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/getsentry/raven-go"
+	"github.com/alfatraining/raven-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
# do not merge this

temporary (hopefully)

I'm hoping to get the change in `alfatraining/raven-go` merged upstream so I can switch back to that repo, but until that happens, I'm forced to use this fork.